### PR TITLE
Use package name instead of path

### DIFF
--- a/lib/inline.js
+++ b/lib/inline.js
@@ -1,4 +1,4 @@
-var beautifyHtml = require('../node_modules/js-beautify/js/lib/beautify-html.js').html_beautify;
+var beautifyHtml = require('js-beautify/js/lib/beautify-html.js').html_beautify;
 var cheerio = require('cheerio');
 var inlineCss = require('inline-css');
 var siphonMQ = require('siphon-media-query');


### PR DESCRIPTION
We should not point to a folder or folder name but instead reference the dependency by name and then use the path which also works.