### PR TITLE
Use terser to support ES6 (const and more)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "watchify index.js --debug -o script.js",
-    "build": "browserify index.js | uglifyjs > inliner.min.js",
+    "build": "browserify index.js | terser > inliner.min.js",
     "test": "mocha"
   },
   "author": "ZURB <foundation@zurb.com> (http://get.foundation.com)",
@@ -13,7 +13,7 @@
   "devDependencies": {
     "browserify": "^13.0.0",
     "mocha": "^2.4.5",
-    "uglify-js": "^2.6.2",
+    "terser": "^4.4.3",
     "watchify": "^3.7.0"
   },
   "dependencies": {


### PR DESCRIPTION
This PR migrates the setup to terser bause uglify-js can not minify the current files as they use `const` which is not supported.