### PR TITLE
Add command line interface to inliner

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ npm install
 Run `npm start` to start the build process. A new JavaScript bundle will be generated each time you save `index.js`.
 
 Run `npm run build` to generate a compressed bundle. Use this compressed file on the Foundation marketing site.
+
+## Running locally
+
+You can use the small wrapper script (`cli.js`) to perform inlining from
+the command line.
+
+Example usage:
+
+    $ node cli.js path/to/index.html path/to/css/foundation-emails.css > /tmp/output.html

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,32 @@
+// Command line interface to the inliner.
+//
+// Example usage:
+//     $ node cli.js path/to/index.html path/to/css/foundation-emails.css > /tmp/output.html
+
+const fs = require('fs');
+const inline = require('./lib/inline');
+
+const onSuccess = (html) => {
+    console.log(html);
+};
+
+const onError = (err) => {
+    console.log(`Error :( ${err}`);
+};
+
+const main = () => {
+    const userArgs = process.argv.slice(2);
+    const htmlSourceFile = userArgs[0];
+    const cssSourceFile = userArgs[1];
+
+    const htmlData = fs.readFileSync(htmlSourceFile);
+    const cssData = fs.readFileSync(cssSourceFile);
+
+    inline(htmlData.toString(), cssData.toString(), {
+        compress: process.argv.indexOf('--compress') >= 0,
+        onSuccess: onSuccess,
+        onError: onError
+    });
+};
+
+main();


### PR DESCRIPTION
It can be handy to run the inliner from the command line (for use in build pipelines, etc). Add a small wrapper script that can be executed with node to perform inlining:

    $ node cli.js path/to/index.html path/to/css/foundation-emails.css > /tmp/output.html